### PR TITLE
Fix back links on works pages

### DIFF
--- a/works/decodification-live-2022.html
+++ b/works/decodification-live-2022.html
@@ -30,7 +30,7 @@
 <p class="meta">2022</p>
 <p><a href="https://youtu.be/vfZLgkD0rGo" target="_blank" rel="noreferrer">watch / listen</a></p>
 <p>Short description coming soon.</p>
-<p><a href="/performances/">← back</a></p>
+<p><a href="/works/">← back</a></p>
 
   </main>
   <footer class="footer">© Myungseok, 2025</footer>

--- a/works/exploration-eight-sounds-2022.html
+++ b/works/exploration-eight-sounds-2022.html
@@ -30,7 +30,7 @@
 <p class="meta">2022</p>
 <p><a href="https://youtu.be/9eyTuvCGrbU" target="_blank" rel="noreferrer">watch / listen</a></p>
 <p>Short description coming soon.</p>
-<p><a href="/performances/">← back</a></p>
+<p><a href="/works/">← back</a></p>
 
   </main>
   <footer class="footer">© Myungseok, 2025</footer>

--- a/works/hotel-meta-2022.html
+++ b/works/hotel-meta-2022.html
@@ -30,7 +30,7 @@
 <p class="meta">2022</p>
 <p><a href="https://youtu.be/-wbAdOSZ4Ac" target="_blank" rel="noreferrer">watch / listen</a></p>
 <p>Short description coming soon.</p>
-<p><a href="/exhibitions/">← back</a></p>
+<p><a href="/works/">← back</a></p>
 
   </main>
   <footer class="footer">© Myungseok, 2025</footer>

--- a/works/sensation-discovery-2022.html
+++ b/works/sensation-discovery-2022.html
@@ -30,7 +30,7 @@
 <p class="meta">2022</p>
 <p><a href="https://youtu.be/HySczQ1A1xs" target="_blank" rel="noreferrer">watch / listen</a></p>
 <p>Short description coming soon.</p>
-<p><a href="/exhibitions/">← back</a></p>
+<p><a href="/works/">← back</a></p>
 
   </main>
   <footer class="footer">© Myungseok, 2025</footer>

--- a/works/trans-2023.html
+++ b/works/trans-2023.html
@@ -30,7 +30,7 @@
 <p class="meta">2023</p>
 <p><a href="https://youtu.be/Ew7WXLwUQYY" target="_blank" rel="noreferrer">watch / listen</a></p>
 <p>Short description coming soon.</p>
-<p><a href="/performances/">← back</a></p>
+<p><a href="/works/">← back</a></p>
 
   </main>
   <footer class="footer">© Myungseok, 2025</footer>


### PR DESCRIPTION
## Summary
- Point "← back" links on works detail pages to `/works/`

## Testing
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &` (followed by curl requests)

------
https://chatgpt.com/codex/tasks/task_b_689f4715dc78832db6a5b24a54165b6b