### PR TITLE
Remove links to missing work pages

### DIFF
--- a/exhibitions/index.html
+++ b/exhibitions/index.html
@@ -29,10 +29,6 @@
 <ul class='list'>
 <li><a href="/works/hotel-meta-2022.html">&quot;Hotel Meta&quot; — VR Exhibition</a> <span class="meta">2022</span></li>
 <li><a href="/works/sensation-discovery-2022.html">&quot;Sensation and Discovery&quot;: Playground of Eight Sounds</a> <span class="meta">2022</span></li>
-<li><a href="/works/erasing-silence-kes-2022.html">Erasing Silence — KES</a> <span class="meta">2022</span></li>
-<li><a href="/works/erasing-silence-vr-2022.html">Erasing Silence — VR Artwork</a> <span class="meta">2022</span></li>
-<li><a href="/works/the-elements-2021.html">The Elements for Electro Acoustics</a> <span class="meta">2021</span></li>
-<li><a href="/works/sonification-project-2019.html">Sonification Project</a> <span class="meta">2019</span></li>
 </ul>
   </main>
   <footer class="footer">© Myungseok, 2025</footer>

--- a/performances/index.html
+++ b/performances/index.html
@@ -30,7 +30,6 @@
 <li><a href="/works/trans-2023.html">&quot;TRANS&quot;</a> <span class="meta">2023</span></li>
 <li><a href="/works/decodification-live-2022.html">Decodification for Live Electronics</a> <span class="meta">2022</span></li>
 <li><a href="/works/exploration-eight-sounds-2022.html">&quot;Exploration of Eight Sounds&quot; for Live Electronics</a> <span class="meta">2022</span></li>
-<li><a href="/works/salvation-from-melancholy-2021.html">&quot;Salvation from Melancholy&quot; for Live Electronics</a> <span class="meta">2021</span></li>
 </ul>
   </main>
   <footer class="footer">© Myungseok, 2025</footer>

--- a/recordings/index.html
+++ b/recordings/index.html
@@ -27,10 +27,7 @@
   <main class="container">
   <h2>recordings</h2>
 <ul class='list'>
-<li><a href="/works/sound-postcard-tancheon-2022.html">Sound Postcard &quot;Tancheon River&quot;</a> <span class="meta">2022</span></li>
-<li><a href="/works/to-my-mojave-binaural-2022.html">&quot;To My Mojave&quot; (Binaural &amp; Audio Reactive)</a> <span class="meta">2022</span></li>
-<li><a href="/works/to-my-mojave-2021.html">&quot;To My Mojave&quot;</a> <span class="meta">2021</span></li>
-<li><a href="/works/zen-2019.html">&quot;Zen&quot;</a> <span class="meta">2019</span></li>
+<li>coming soon</li>
 </ul>
   </main>
   <footer class="footer">© Myungseok, 2025</footer>

--- a/works/index.html
+++ b/works/index.html
@@ -32,16 +32,6 @@
 <li><a href="/works/decodification-live-2022.html">Decodification for Live Electronics</a> <span class="meta">2022</span></li>
 <li><a href="/works/sensation-discovery-2022.html">&quot;Sensation and Discovery&quot;: Playground of Eight Sounds</a> <span class="meta">2022</span></li>
 <li><a href="/works/exploration-eight-sounds-2022.html">&quot;Exploration of Eight Sounds&quot; for Live Electronics</a> <span class="meta">2022</span></li>
-<li><a href="/works/erasing-silence-kes-2022.html">Erasing Silence — KES</a> <span class="meta">2022</span></li>
-<li><a href="/works/erasing-silence-vr-2022.html">Erasing Silence — VR Artwork</a> <span class="meta">2022</span></li>
-<li><a href="/works/sound-postcard-tancheon-2022.html">Sound Postcard &quot;Tancheon River&quot;</a> <span class="meta">2022</span></li>
-<li><a href="/works/to-my-mojave-binaural-2022.html">&quot;To My Mojave&quot; (Binaural &amp; Audio Reactive)</a> <span class="meta">2022</span></li>
-<li><a href="/works/the-elements-2021.html">The Elements for Electro Acoustics</a> <span class="meta">2021</span></li>
-<li><a href="/works/to-my-mojave-2021.html">&quot;To My Mojave&quot;</a> <span class="meta">2021</span></li>
-<li><a href="/works/salvation-from-melancholy-2021.html">&quot;Salvation from Melancholy&quot; for Live Electronics</a> <span class="meta">2021</span></li>
-<li><a href="/works/sonification-project-2019.html">Sonification Project</a> <span class="meta">2019</span></li>
-<li><a href="/works/zen-2019.html">&quot;Zen&quot;</a> <span class="meta">2019</span></li>
-<li><a href="/works/we-do-not-recall-2015.html">&quot;WE DO NOT RECALL&quot;</a> <span class="meta">2015</span></li>
 </ul>
   </main>
   <footer class="footer">© Myungseok, 2025</footer>


### PR DESCRIPTION
## Summary
- prune missing work entries from works listing
- remove stale links in exhibitions, performances, and recordings sections
- add placeholder for recordings until content is available

## Testing
- `python -m http.server 8000` and curl requests for updated pages

------
https://chatgpt.com/codex/tasks/task_b_689f491d88a0832dae30c312e05a4b61