### PR TITLE
Embed YouTube videos on work pages

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -11,3 +11,4 @@ h1,h2,h3{font-weight:600;margin:0 0 12px}h1{font-size:20px}h2{font-size:18px;mar
 .list{margin:8px 0 0;padding:0;list-style:none}.list li{margin:4px 0}.meta{color:var(--muted);font-size:13px;margin-left:8px}
 .footer{color:var(--muted);font-size:12px;padding:24px 16px;border-top:1px solid #eee}
 .container p{margin:0 0 16px}
+.video-container iframe{width:100%;aspect-ratio:16/9}

--- a/works/decodification-live-2022.html
+++ b/works/decodification-live-2022.html
@@ -28,7 +28,12 @@
   
 <h2>Decodification for Live Electronics</h2>
 <p class="meta">2022</p>
-<p><a href="https://youtu.be/vfZLgkD0rGo" target="_blank" rel="noreferrer">watch / listen</a></p>
+<div class="video-container">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/vfZLgkD0rGo"
+          title="Decodification for Live Electronics" frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen></iframe>
+</div>
 <p>Short description coming soon.</p>
 <p><a href="/works/">← back</a></p>
 

--- a/works/exploration-eight-sounds-2022.html
+++ b/works/exploration-eight-sounds-2022.html
@@ -28,7 +28,12 @@
   
 <h2>&quot;Exploration of Eight Sounds&quot; for Live Electronics</h2>
 <p class="meta">2022</p>
-<p><a href="https://youtu.be/9eyTuvCGrbU" target="_blank" rel="noreferrer">watch / listen</a></p>
+<div class="video-container">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/9eyTuvCGrbU"
+          title="&quot;Exploration of Eight Sounds&quot; for Live Electronics" frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen></iframe>
+</div>
 <p>Short description coming soon.</p>
 <p><a href="/works/">← back</a></p>
 

--- a/works/hotel-meta-2022.html
+++ b/works/hotel-meta-2022.html
@@ -28,7 +28,12 @@
   
 <h2>&quot;Hotel Meta&quot; — VR Exhibition</h2>
 <p class="meta">2022</p>
-<p><a href="https://youtu.be/-wbAdOSZ4Ac" target="_blank" rel="noreferrer">watch / listen</a></p>
+<div class="video-container">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/-wbAdOSZ4Ac"
+          title="&quot;Hotel Meta&quot; — VR Exhibition" frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen></iframe>
+</div>
 <p>Short description coming soon.</p>
 <p><a href="/works/">← back</a></p>
 

--- a/works/sensation-discovery-2022.html
+++ b/works/sensation-discovery-2022.html
@@ -28,7 +28,12 @@
   
 <h2>&quot;Sensation and Discovery&quot;: Playground of Eight Sounds</h2>
 <p class="meta">2022</p>
-<p><a href="https://youtu.be/HySczQ1A1xs" target="_blank" rel="noreferrer">watch / listen</a></p>
+<div class="video-container">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/HySczQ1A1xs"
+          title="&quot;Sensation and Discovery&quot;: Playground of Eight Sounds" frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen></iframe>
+</div>
 <p>Short description coming soon.</p>
 <p><a href="/works/">← back</a></p>
 

--- a/works/trans-2023.html
+++ b/works/trans-2023.html
@@ -28,7 +28,12 @@
   
 <h2>&quot;TRANS&quot;</h2>
 <p class="meta">2023</p>
-<p><a href="https://youtu.be/Ew7WXLwUQYY" target="_blank" rel="noreferrer">watch / listen</a></p>
+<div class="video-container">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/Ew7WXLwUQYY"
+          title="&quot;TRANS&quot;" frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen></iframe>
+</div>
 <p>Short description coming soon.</p>
 <p><a href="/works/">← back</a></p>
 


### PR DESCRIPTION
## Summary
- Replace external YouTube watch links with inline iframe embeds on all work pages
- Add responsive styling for video iframes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a028c07ef0832d8cc7a5e02bcf4fa4