### PR TITLE
Embed SoundCloud player on recordings page

### DIFF
--- a/recordings/index.html
+++ b/recordings/index.html
@@ -27,7 +27,9 @@
   <main class="container">
   <h2>recordings</h2>
 <ul class='list'>
-<li>coming soon</li>
+  <li>
+    <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/forss/flickermood&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
+  </li>
 </ul>
   </main>
   <footer class="footer">© Myungseok, 2025</footer>


### PR DESCRIPTION
## Summary
- Replace placeholder on recordings page with embedded SoundCloud iframe

## Testing
- `npx html-validate recordings/index.html` *(fails: 403 Forbidden)*
- `tidy -q -e recordings/index.html` *(fails: command not found)*
- `pip install --quiet html5validator && html5validator recordings/index.html` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_b_68a065175fd0832d8e13b1ac7267431c