### PR TITLE
Fix SoundCloud embed on recordings page

### DIFF
--- a/recordings/index.html
+++ b/recordings/index.html
@@ -32,10 +32,10 @@
       width="100%" height="166"
       scrolling="no" frameborder="no"
       allow="autoplay"
-      src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/TRACK_ID&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true">
+      src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/hearenzo/fractal-resonance&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true">
     </iframe>
     <div style="font-size:10px;color:#ccc;">
-      <a href="https://soundcloud.com/hearenzo" target="_blank" style="color:#ccc;text-decoration:none;">ARTIST</a> ·
+      <a href="https://soundcloud.com/hearenzo" target="_blank" style="color:#ccc;text-decoration:none;">hearenzo</a> ·
       <a href="https://soundcloud.com/hearenzo/fractal-resonance" target="_blank" style="color:#ccc;text-decoration:none;">Fractal Resonance</a>
     </div>
   </li>


### PR DESCRIPTION
## Summary
- fix SoundCloud iframe to use actual track URL instead of placeholder
- show SoundCloud artist name

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0701ea098832d9036149c678130f0