### PR TITLE
Remove references to retired exhibition and performance pages

### DIFF
--- a/biography/index.html
+++ b/biography/index.html
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>

--- a/contact/index.html
+++ b/contact/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Myungseok — contact</title>
-  <meta name="description" content="Myungseok — minimalist portfolio. News, works, exhibitions, performances, recordings, publications, biography, contact." />
+  <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
 </head>
 <body>
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Myungseok — news</title>
-  <meta name="description" content="Myungseok — minimalist portfolio. News, works, exhibitions, performances, recordings, publications, biography, contact." />
+  <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="assets/css/styles.css" />
 </head>
 <body>
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>

--- a/publications/index.html
+++ b/publications/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Myungseok — publications</title>
-  <meta name="description" content="Myungseok — minimalist portfolio. News, works, exhibitions, performances, recordings, publications, biography, contact." />
+  <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
 </head>
 <body>
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>

--- a/recordings/index.html
+++ b/recordings/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Myungseok — recordings</title>
-  <meta name="description" content="Myungseok — minimalist portfolio. News, works, exhibitions, performances, recordings, publications, biography, contact." />
+  <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
 </head>
 <body>
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>

--- a/works/decodification-live-2022.html
+++ b/works/decodification-live-2022.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Decodification for Live Electronics — Myungseok</title>
-  <meta name="description" content="Myungseok — minimalist portfolio. News, works, exhibitions, performances, recordings, publications, biography, contact." />
+  <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
 </head>
 <body>
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>

--- a/works/erasing silence-2022.html
+++ b/works/erasing silence-2022.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>&quot;Erasing Silence&quot; — Myungseok</title>
-  <meta name="description" content="Myungseok — minimalist portfolio. News, works, exhibitions, performances, recordings, publications, biography, contact." />
+  <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
 </head>
 <body>
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>

--- a/works/exploration-eight-sounds-2022.html
+++ b/works/exploration-eight-sounds-2022.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>&quot;Exploration of Eight Sounds&quot; for Live Electronics — Myungseok</title>
-  <meta name="description" content="Myungseok — minimalist portfolio. News, works, exhibitions, performances, recordings, publications, biography, contact." />
+  <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
 </head>
 <body>
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>

--- a/works/hotel-meta-2022.html
+++ b/works/hotel-meta-2022.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>&quot;Hotel Meta&quot; — VR Exhibition — Myungseok</title>
-  <meta name="description" content="Myungseok — minimalist portfolio. News, works, exhibitions, performances, recordings, publications, biography, contact." />
+  <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
 </head>
 <body>
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>

--- a/works/index.html
+++ b/works/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Myungseok — works</title>
-  <meta name="description" content="Myungseok — minimalist portfolio. News, works, exhibitions, performances, recordings, publications, biography, contact." />
+  <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
 </head>
 <body>
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>

--- a/works/salvation from melancholy-2022.html
+++ b/works/salvation from melancholy-2022.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>&quot;Salvation from Melancholy&quot; — Myungseok</title>
-  <meta name="description" content="Myungseok — minimalist portfolio. News, works, exhibitions, performances, recordings, publications, biography, contact." />
+  <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
 </head>
 <body>
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>

--- a/works/sensation-discovery-2022.html
+++ b/works/sensation-discovery-2022.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>&quot;Sensation and Discovery&quot;: Playground of Eight Sounds — Myungseok</title>
-  <meta name="description" content="Myungseok — minimalist portfolio. News, works, exhibitions, performances, recordings, publications, biography, contact." />
+  <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
 </head>
 <body>
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>

--- a/works/sonification project-2019.html
+++ b/works/sonification project-2019.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>&quot;Sonification Project&quot; — Myungseok</title>
-  <meta name="description" content="Myungseok — minimalist portfolio. News, works, exhibitions, performances, recordings, publications, biography, contact." />
+  <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
 </head>
 <body>
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>

--- a/works/tancheon river-2022.html
+++ b/works/tancheon river-2022.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>&quot;Tancheon River&quot; — Myungseok</title>
-  <meta name="description" content="Myungseok — minimalist portfolio. News, works, exhibitions, performances, recordings, publications, biography, contact." />
+  <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
 </head>
 <body>
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>

--- a/works/the elements for electro acoustics.html
+++ b/works/the elements for electro acoustics.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>&quot;The Elements for Electro Acoustics&quot; — Myungseok</title>
-  <meta name="description" content="Myungseok — minimalist portfolio. News, works, exhibitions, performances, recordings, publications, biography, contact." />
+  <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
 </head>
 <body>
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>

--- a/works/to my mojave-2021.html
+++ b/works/to my mojave-2021.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>&quot;To My Mojave&quot; — Myungseok</title>
-  <meta name="description" content="Myungseok — minimalist portfolio. News, works, exhibitions, performances, recordings, publications, biography, contact." />
+  <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
 </head>
 <body>
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>

--- a/works/trans-2023.html
+++ b/works/trans-2023.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>&quot;TRANS&quot; — Myungseok</title>
-  <meta name="description" content="Myungseok — minimalist portfolio. News, works, exhibitions, performances, recordings, publications, biography, contact." />
+  <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
 </head>
 <body>
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>

--- a/works/we do not recall-2015.html
+++ b/works/we do not recall-2015.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>&quot;WE DO NOT RECALL&quot; — Myungseok</title>
-  <meta name="description" content="Myungseok — minimalist portfolio. News, works, exhibitions, performances, recordings, publications, biography, contact." />
+  <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
 </head>
 <body>
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>

--- a/works/zen-2019.html
+++ b/works/zen-2019.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>&quot;Zen&quot; — Myungseok</title>
-  <meta name="description" content="Myungseok — minimalist portfolio. News, works, exhibitions, performances, recordings, publications, biography, contact." />
+  <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
 </head>
 <body>
@@ -14,8 +14,6 @@
       <ul>
         <li><a href="/">news</a></li>
         <li><a href="/works/">works</a></li>
-        <li><a href="/exhibitions/">exhibitions</a></li>
-        <li><a href="/performances/">performances</a></li>
         <li><a href="/recordings/">recordings</a></li>
         <li><a href="/publications/">publications</a></li>
         <li><a href="/biography/">biography</a></li>


### PR DESCRIPTION
## Summary
- Remove exhibition and performance links from site navigation
- Update meta descriptions across pages to exclude retired sections

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a0b37afbd0832d8001110f9be64a89