### PR TITLE
Add inline favicon and preview metadata

### DIFF
--- a/biography/index.html
+++ b/biography/index.html
@@ -6,6 +6,16 @@
   <meta name="description" content="Myungseok Oh — Seoul-based sound artist & artistic researcher. Artistic statement, education, residencies, research, and awards." />
   <title>Biography — Myungseok Oh</title>
   <link rel="stylesheet" href="../assets/css/styles.css" />
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <meta property="og:title" content="Biography — Myungseok Oh" />
+  <meta property="og:description" content="Myungseok Oh — Seoul-based sound artist & artistic researcher. Artistic statement, education, residencies, research, and awards." />
+  <meta property="og:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
+  <meta property="og:url" content="https://hearenzo.github.io/biography/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Biography — Myungseok Oh" />
+  <meta name="twitter:description" content="Myungseok Oh — Seoul-based sound artist & artistic researcher. Artistic statement, education, residencies, research, and awards." />
+  <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
   <header class="container">

--- a/contact/index.html
+++ b/contact/index.html
@@ -6,6 +6,16 @@
   <title>Myungseok — contact</title>
   <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <meta property="og:title" content="Myungseok — contact" />
+  <meta property="og:description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
+  <meta property="og:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
+  <meta property="og:url" content="https://hearenzo.github.io/contact/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myungseok — contact" />
+  <meta name="twitter:description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
+  <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
   <header class="container">

--- a/index.html
+++ b/index.html
@@ -6,6 +6,16 @@
   <title>Myungseok — news</title>
   <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="assets/css/styles.css" />
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <meta property="og:title" content="Myungseok — news" />
+  <meta property="og:description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
+  <meta property="og:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
+  <meta property="og:url" content="https://hearenzo.github.io/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myungseok — news" />
+  <meta name="twitter:description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
+  <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
   <header class="container">

--- a/publications/index.html
+++ b/publications/index.html
@@ -6,6 +6,16 @@
   <title>Myungseok — publications</title>
   <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <meta property="og:title" content="Myungseok — publications" />
+  <meta property="og:description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
+  <meta property="og:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
+  <meta property="og:url" content="https://hearenzo.github.io/publications/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myungseok — publications" />
+  <meta name="twitter:description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
+  <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
   <header class="container">

--- a/recordings/index.html
+++ b/recordings/index.html
@@ -6,6 +6,16 @@
   <title>Myungseok — recordings</title>
   <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="../assets/css/styles.css" />
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <meta property="og:title" content="Myungseok — recordings" />
+  <meta property="og:description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
+  <meta property="og:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
+  <meta property="og:url" content="https://hearenzo.github.io/recordings/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myungseok — recordings" />
+  <meta name="twitter:description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
+  <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
   <header class="container">

--- a/works/index.html
+++ b/works/index.html
@@ -6,6 +6,16 @@
   <title>Myungseok — works</title>
   <meta name="description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
   <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <meta property="og:title" content="Myungseok — works" />
+  <meta property="og:description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
+  <meta property="og:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
+  <meta property="og:url" content="https://hearenzo.github.io/works/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myungseok — works" />
+  <meta name="twitter:description" content="Myungseok — minimalist portfolio. News, works, recordings, publications, biography, contact." />
+  <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
   <header class="container">


### PR DESCRIPTION
## Summary
- remove binary image assets to avoid unsupported binaries
- inline small placeholder images in favicon and social preview meta tags across pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a0c000cbf4832d90a3bd30f3dbc30a