### PR TITLE
Fix placeholders in TRANS project description

### DIFF
--- a/works/trans-2023/index.html
+++ b/works/trans-2023/index.html
@@ -35,7 +35,7 @@
 <p><strong>Dates</strong>: October 21-22, 2023</p>
 <p><strong>Location</strong>: Studio Mong</p>
 <p><strong>Dialogue and Communication, Individual Expressions, Common Language</strong></p>
-<p>The project focuses on recognizing and moving within the state of transformation, even though it’s uncertain what form our changes will take. It defines the bodies on stage as , and the awakening of all senses and individual expressive languages as .</p>
+<p>The project focuses on recognizing and moving within the state of transformation, even though it’s uncertain what form our changes will take. It defines the bodies on stage as forms, and the awakening of all senses and individual expressive languages as sensations.</p>
 <p>Forms communicate with forms, forms with phenomena, and phenomena with phenomena, engaging in a dialogue that seems to mimic communication. This interaction influences all senses and promotes change.</p>
 <p>It resembles contagious laughter, spreading like a virus. Interestingly, while their communication might be seamless at times, errors can occur, leading to changes in different or opposite directions. What forms will they take, and which directions will they head?</p>
 <p><strong>Copyright © TRANS All rights reserved.</strong></p>


### PR DESCRIPTION
## Summary
- Fill placeholder descriptors in the TRANS project paragraph to read as complete sentences
- Add trailing newline for consistent formatting

## Testing
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_b_68a0d1a3f808832d8c285fffa6bab152