### PR TITLE
Expand CSS and add build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+assets/css/styles.min.css

--- a/README.md
+++ b/README.md
@@ -18,3 +18,13 @@ A GitHub Actions workflow runs [Lychee](https://github.com/lycheeverse/lychee) t
    ```
 
 The command exits with a non-zero status if any links are unreachable.
+
+## CSS build
+
+To generate a minified stylesheet for production, run:
+
+```bash
+npm run build
+```
+
+The command writes the output to `assets/css/styles.min.css`.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,14 +1,132 @@
-:root{--bg:#fff;--fg:#000;--muted:#666;--maxw:900px}
-*{box-sizing:border-box}html,body{margin:0;padding:0}
-body{font-family:system-ui,-apple-system,"Segoe UI",Roboto,"Noto Sans KR",Arial,sans-serif;background:var(--bg);color:var(--fg);line-height:1.6;letter-spacing:.015em}
-a{color:var(--fg);text-decoration:none;border-bottom:1px solid transparent}
-a:hover{border-bottom-color:var(--fg)}
-header,main,footer{width:100%}.container{max-width:var(--maxw);margin:0 auto;padding:24px 16px}
-nav ul{list-style:none;padding:0;margin:0;display:flex;flex-wrap:wrap;gap:16px}
-nav a{text-transform:lowercase;font-size:14px}
-hr{border:0;border-top:1px solid #ddd;margin:24px 0}
-h1,h2,h3{font-weight:600;margin:0 0 12px}h1{font-size:20px}h2{font-size:18px;margin-top:24px}h3{font-size:16px;margin-top:16px}
-.list{margin:8px 0 0;padding:0;list-style:none}.list li{margin:4px 0}.meta{color:var(--muted);font-size:13px;margin-left:8px}
-.footer{color:var(--muted);font-size:12px;padding:24px 16px;border-top:1px solid #eee}
-.container p{margin:0 0 16px}
-.video-container iframe{width:100%;aspect-ratio:16/9}
+/* Theme variables */
+:root {
+  --bg: #fff;
+  --fg: #000;
+  --muted: #666;
+  --maxw: 900px;
+}
+
+/* Box sizing reset */
+* {
+  box-sizing: border-box;
+}
+
+/* Remove default margin/padding */
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+/* Body defaults */
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Noto Sans KR", Arial, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.6;
+  letter-spacing: 0.015em;
+}
+
+/* Links */
+a {
+  color: var(--fg);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+}
+
+a:hover {
+  border-bottom-color: var(--fg);
+}
+
+/* Layout */
+header,
+main,
+footer {
+  width: 100%;
+}
+
+.container {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 24px 16px;
+}
+
+/* Navigation */
+nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+nav a {
+  text-transform: lowercase;
+  font-size: 14px;
+}
+
+/* Horizontal rule */
+hr {
+  border: 0;
+  border-top: 1px solid #ddd;
+  margin: 24px 0;
+}
+
+/* Headings */
+h1,
+h2,
+h3 {
+  font-weight: 600;
+  margin: 0 0 12px;
+}
+
+h1 {
+  font-size: 20px;
+}
+
+h2 {
+  font-size: 18px;
+  margin-top: 24px;
+}
+
+h3 {
+  font-size: 16px;
+  margin-top: 16px;
+}
+
+/* Lists */
+.list {
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.list li {
+  margin: 4px 0;
+}
+
+.meta {
+  color: var(--muted);
+  font-size: 13px;
+  margin-left: 8px;
+}
+
+/* Footer */
+.footer {
+  color: var(--muted);
+  font-size: 12px;
+  padding: 24px 16px;
+  border-top: 1px solid #eee;
+}
+
+/* Paragraph spacing */
+.container p {
+  margin: 0 0 16px;
+}
+
+/* Responsive video embeds */
+.video-container iframe {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "hearenzo.github.io",
+  "version": "1.0.0",
+  "description": "Static site for Myungseok Oh.",
+  "private": true,
+  "scripts": {
+    "build": "node scripts/minify-css.js",
+    "test": "echo \"No tests specified\""
+  }
+}

--- a/scripts/minify-css.js
+++ b/scripts/minify-css.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+
+const inputPath = path.join(__dirname, '..', 'assets', 'css', 'styles.css');
+const outputPath = path.join(__dirname, '..', 'assets', 'css', 'styles.min.css');
+
+const css = fs.readFileSync(inputPath, 'utf8');
+
+const minified = css
+  .replace(/\/\*[^]*?\*\//g, '') // remove comments
+  .replace(/\s+/g, ' ') // collapse whitespace
+  .replace(/\s*([:;{}])\s*/g, '$1') // remove spaces around tokens
+  .trim();
+
+fs.writeFileSync(outputPath, minified);
+console.log(`Minified CSS written to ${outputPath}`);


### PR DESCRIPTION
## Summary
- Expand `assets/css/styles.css` into a readable, commented format.
- Add a simple Node script and npm build command to output a minified stylesheet.
- Document the CSS build step in the README and ignore generated artifacts.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a471da4ac4832d98bbb75dfe3ea9ca