### PR TITLE
Refactor layout with includes and add social metadata

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,1 @@
+<footer class="footer">© Myungseok Oh, 2025</footer>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,14 @@
+<header class="container">
+  <h1><a href="/">Myungseok Oh</a></h1>
+  <nav>
+    <ul>
+      <li><a href="/">news</a></li>
+      <li><a href="/works/">works</a></li>
+      <li><a href="/recordings/">recordings</a></li>
+      <li><a href="/publications/">publications</a></li>
+      <li><a href="/biography/">biography</a></li>
+      <li><a href="/contact/">contact</a></li>
+    </ul>
+  </nav>
+  <hr />
+</header>

--- a/biography/index.html
+++ b/biography/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -18,20 +20,7 @@
   <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
-  <header class="container">
-    <h1><a href="/">Myungseok Oh</a></h1>
-    <nav>
-      <ul>
-        <li><a href="/">news</a></li>
-        <li><a href="/works/">works</a></li>
-        <li><a href="/recordings/">recordings</a></li>
-        <li><a href="/publications/">publications</a></li>
-        <li><a href="/biography/">biography</a></li>
-        <li><a href="/contact/">contact</a></li>
-      </ul>
-    </nav>
-    <hr />
-  </header>
+  {% include header.html %}
 
   <main class="container">
     <h2>biography</h2>
@@ -145,9 +134,6 @@ experiences, choices, and the essence of the natural elements that inspired it.
         <a href="https://www.hankookilbo.com/News/Read/201807181662031986" target="_blank" rel="noreferrer">press</a>
       </li>
     </ul>
-
-  <footer class="footer">
-    © Myungseok Oh, 2025
-  </footer>
+  {% include footer.html %}
 </body>
 </html>

--- a/contact/index.html
+++ b/contact/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -18,24 +20,11 @@
   <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
-  <header class="container">
-    <h1><a href="/">Myungseok Oh</a></h1>
-    <nav>
-      <ul>
-        <li><a href="/">news</a></li>
-        <li><a href="/works/">works</a></li>
-        <li><a href="/recordings/">recordings</a></li>
-        <li><a href="/publications/">publications</a></li>
-        <li><a href="/biography/">biography</a></li>
-        <li><a href="/contact/">contact</a></li>
-      </ul>
-    </nav>
-    <hr />
-  </header>
+  {% include header.html %}
   <main class="container">
   <h2>contact</h2>
 <p>email: <a href="mailto:hearenzo@naver.com">hearenzo@naver.com</a></p>
   </main>
-  <footer class="footer">© Myungseok Oh, 2025</footer>
+  {% include footer.html %}
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -18,24 +20,11 @@
   <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
-  <header class="container">
-    <h1><a href="/">Myungseok Oh</a></h1>
-    <nav>
-      <ul>
-        <li><a href="/">news</a></li>
-        <li><a href="/works/">works</a></li>
-        <li><a href="/recordings/">recordings</a></li>
-        <li><a href="/publications/">publications</a></li>
-        <li><a href="/biography/">biography</a></li>
-        <li><a href="/contact/">contact</a></li>
-      </ul>
-    </nav>
-    <hr />
-  </header>
+  {% include header.html %}
   <main class="container">
   <h2>news</h2>
 <ul class='list'><li>coming soon</li></ul>
   </main>
-  <footer class="footer">© Myungseok Oh, 2025</footer>
+  {% include footer.html %}
 </body>
 </html>

--- a/publications/index.html
+++ b/publications/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -18,20 +20,7 @@
   <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
-  <header class="container">
-    <h1><a href="/">Myungseok Oh</a></h1>
-    <nav>
-      <ul>
-        <li><a href="/">news</a></li>
-        <li><a href="/works/">works</a></li>
-        <li><a href="/recordings/">recordings</a></li>
-        <li><a href="/publications/">publications</a></li>
-        <li><a href="/biography/">biography</a></li>
-        <li><a href="/contact/">contact</a></li>
-      </ul>
-    </nav>
-    <hr />
-  </header>
+  {% include header.html %}
   <main class="container">
   <h2>publications</h2>
 
@@ -41,6 +30,6 @@
 </ul>
 
   </main>
-  <footer class="footer">© Myungseok Oh, 2025</footer>
+  {% include footer.html %}
 </body>
 </html>

--- a/recordings/index.html
+++ b/recordings/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -18,20 +20,7 @@
   <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
-  <header class="container">
-    <h1><a href="/">Myungseok Oh</a></h1>
-    <nav>
-      <ul>
-        <li><a href="/">news</a></li>
-        <li><a href="/works/">works</a></li>
-        <li><a href="/recordings/">recordings</a></li>
-        <li><a href="/publications/">publications</a></li>
-        <li><a href="/biography/">biography</a></li>
-        <li><a href="/contact/">contact</a></li>
-      </ul>
-    </nav>
-    <hr />
-  </header>
+  {% include header.html %}
   <main class="container">
   <h2>recordings</h2>
 <ul class='list'>
@@ -97,6 +86,6 @@
   </li>       
 </ul>
   </main>
-  <footer class="footer">© Myungseok Oh, 2025</footer>
+  {% include footer.html %}
 </body>
 </html>

--- a/works/decodification-live-2022/index.html
+++ b/works/decodification-live-2022/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -6,22 +8,19 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
+  <meta property="og:url" content="https://hearenzo.github.io/works/decodification-live-2022/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
-  <header class="container">
-    <h1><a href="/">Myungseok Oh</a></h1>
-    <nav>
-      <ul>
-        <li><a href="/">news</a></li>
-        <li><a href="/works/">works</a></li>
-        <li><a href="/recordings/">recordings</a></li>
-        <li><a href="/publications/">publications</a></li>
-        <li><a href="/biography/">biography</a></li>
-        <li><a href="/contact/">contact</a></li>
-      </ul>
-    </nav>
-    <hr />
-  </header>
+  {% include header.html %}
   <main class="container">
   
 <h2>Decodification for Live Electronics</h2>
@@ -39,6 +38,6 @@
 <p><a href="/works/">← back</a></p>
 
   </main>
-  <footer class="footer">© Myungseok Oh, 2025</footer>
+  {% include footer.html %}
 </body>
 </html>

--- a/works/erasing-silence-2022/index.html
+++ b/works/erasing-silence-2022/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -6,22 +8,19 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
+  <meta property="og:url" content="https://hearenzo.github.io/works/erasing-silence-2022/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
-  <header class="container">
-    <h1><a href="/">Myungseok Oh</a></h1>
-    <nav>
-      <ul>
-        <li><a href="/">news</a></li>
-        <li><a href="/works/">works</a></li>
-        <li><a href="/recordings/">recordings</a></li>
-        <li><a href="/publications/">publications</a></li>
-        <li><a href="/biography/">biography</a></li>
-        <li><a href="/contact/">contact</a></li>
-      </ul>
-    </nav>
-    <hr />
-  </header>
+  {% include header.html %}
   <main class="container">
 
 <h2>&quot;Erasing Silence&quot;</h2>
@@ -41,6 +40,6 @@
 <p><a href="/works/">← back</a></p>
 
   </main>
-  <footer class="footer">© Myungseok Oh, 2025</footer>
+  {% include footer.html %}
 </body>
 </html>

--- a/works/exploration-eight-sounds-2022/index.html
+++ b/works/exploration-eight-sounds-2022/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -6,22 +8,19 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
+  <meta property="og:url" content="https://hearenzo.github.io/works/exploration-eight-sounds-2022/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
-  <header class="container">
-    <h1><a href="/">Myungseok Oh</a></h1>
-    <nav>
-      <ul>
-        <li><a href="/">news</a></li>
-        <li><a href="/works/">works</a></li>
-        <li><a href="/recordings/">recordings</a></li>
-        <li><a href="/publications/">publications</a></li>
-        <li><a href="/biography/">biography</a></li>
-        <li><a href="/contact/">contact</a></li>
-      </ul>
-    </nav>
-    <hr />
-  </header>
+  {% include header.html %}
   <main class="container">
   
 <h2>&quot;Exploration of Eight Sounds&quot; for Live Electronics</h2>
@@ -39,6 +38,6 @@
 <p><a href="/works/">← back</a></p>
 
   </main>
-  <footer class="footer">© Myungseok Oh, 2025</footer>
+  {% include footer.html %}
 </body>
 </html>

--- a/works/hotel-meta-2022/index.html
+++ b/works/hotel-meta-2022/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -6,22 +8,19 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
+  <meta property="og:url" content="https://hearenzo.github.io/works/hotel-meta-2022/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
-  <header class="container">
-    <h1><a href="/">Myungseok Oh</a></h1>
-    <nav>
-      <ul>
-        <li><a href="/">news</a></li>
-        <li><a href="/works/">works</a></li>
-        <li><a href="/recordings/">recordings</a></li>
-        <li><a href="/publications/">publications</a></li>
-        <li><a href="/biography/">biography</a></li>
-        <li><a href="/contact/">contact</a></li>
-      </ul>
-    </nav>
-    <hr />
-  </header>
+  {% include header.html %}
   <main class="container">
 
 <h2>&quot;Hotel Meta&quot; — VR Exhibition</h2>
@@ -45,6 +44,6 @@
 <p><a href="/works/">← back</a></p>
 
   </main>
-  <footer class="footer">© Myungseok Oh, 2025</footer>
+  {% include footer.html %}
 </body>
 </html>

--- a/works/index.html
+++ b/works/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -18,20 +20,7 @@
   <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
-  <header class="container">
-    <h1><a href="/">Myungseok Oh</a></h1>
-    <nav>
-      <ul>
-        <li><a href="/">news</a></li>
-        <li><a href="/works/">works</a></li>
-        <li><a href="/recordings/">recordings</a></li>
-        <li><a href="/publications/">publications</a></li>
-        <li><a href="/biography/">biography</a></li>
-        <li><a href="/contact/">contact</a></li>
-      </ul>
-    </nav>
-    <hr />
-  </header>
+  {% include header.html %}
   <main class="container">
   <h2>works</h2>
 <ul class='list'>
@@ -49,6 +38,6 @@
 <li><a href="/works/we-do-not-recall-2015/">&quot;WE DO NOT RECALL&quot; - Dance Film</a> <span class="meta">2015</span></li>
 </ul>
   </main>
-  <footer class="footer">© Myungseok Oh, 2025</footer>
+  {% include footer.html %}
 </body>
 </html>

--- a/works/salvation-from-melancholy-2021/index.html
+++ b/works/salvation-from-melancholy-2021/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -6,22 +8,19 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
+  <meta property="og:url" content="https://hearenzo.github.io/works/salvation-from-melancholy-2021/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
-  <header class="container">
-    <h1><a href="/">Myungseok Oh</a></h1>
-    <nav>
-      <ul>
-        <li><a href="/">news</a></li>
-        <li><a href="/works/">works</a></li>
-        <li><a href="/recordings/">recordings</a></li>
-        <li><a href="/publications/">publications</a></li>
-        <li><a href="/biography/">biography</a></li>
-        <li><a href="/contact/">contact</a></li>
-      </ul>
-    </nav>
-    <hr />
-  </header>
+  {% include header.html %}
   <main class="container">
 
 <h2>&quot;Salvation from Melancholy&quot;</h2>
@@ -41,6 +40,6 @@
 <p><a href="/works/">← back</a></p>
 
   </main>
-  <footer class="footer">© Myungseok Oh, 2025</footer>
+  {% include footer.html %}
 </body>
 </html>

--- a/works/sensation-discovery-2022/index.html
+++ b/works/sensation-discovery-2022/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -6,22 +8,19 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
+  <meta property="og:url" content="https://hearenzo.github.io/works/sensation-discovery-2022/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
-  <header class="container">
-    <h1><a href="/">Myungseok Oh</a></h1>
-    <nav>
-      <ul>
-        <li><a href="/">news</a></li>
-        <li><a href="/works/">works</a></li>
-        <li><a href="/recordings/">recordings</a></li>
-        <li><a href="/publications/">publications</a></li>
-        <li><a href="/biography/">biography</a></li>
-        <li><a href="/contact/">contact</a></li>
-      </ul>
-    </nav>
-    <hr />
-  </header>
+  {% include header.html %}
   <main class="container">
   
 <h2>&quot;Sensation and Discovery&quot;: Playground of Eight Sounds</h2>
@@ -47,6 +46,6 @@
 <p><a href="/works/">← back</a></p>
 
   </main>
-  <footer class="footer">© Myungseok Oh, 2025</footer>
+  {% include footer.html %}
 </body>
 </html>

--- a/works/sonification-project-2019/index.html
+++ b/works/sonification-project-2019/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -6,22 +8,19 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
+  <meta property="og:url" content="https://hearenzo.github.io/works/sonification-project-2019/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
-  <header class="container">
-    <h1><a href="/">Myungseok Oh</a></h1>
-    <nav>
-      <ul>
-        <li><a href="/">news</a></li>
-        <li><a href="/works/">works</a></li>
-        <li><a href="/recordings/">recordings</a></li>
-        <li><a href="/publications/">publications</a></li>
-        <li><a href="/biography/">biography</a></li>
-        <li><a href="/contact/">contact</a></li>
-      </ul>
-    </nav>
-    <hr />
-  </header>
+  {% include header.html %}
   <main class="container">
 
 <h2>&quot;Sonification Project&quot;</h2>
@@ -49,6 +48,6 @@
 <p><a href="/works/">← back</a></p>
 
   </main>
-  <footer class="footer">© Myungseok Oh, 2025</footer>
+  {% include footer.html %}
 </body>
 </html>

--- a/works/the-elements-for-electro-acoustics-2021/index.html
+++ b/works/the-elements-for-electro-acoustics-2021/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -6,22 +8,19 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
+  <meta property="og:url" content="https://hearenzo.github.io/works/the-elements-for-electro-acoustics-2021/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
-  <header class="container">
-    <h1><a href="/">Myungseok Oh</a></h1>
-    <nav>
-      <ul>
-        <li><a href="/">news</a></li>
-        <li><a href="/works/">works</a></li>
-        <li><a href="/recordings/">recordings</a></li>
-        <li><a href="/publications/">publications</a></li>
-        <li><a href="/biography/">biography</a></li>
-        <li><a href="/contact/">contact</a></li>
-      </ul>
-    </nav>
-    <hr />
-  </header>
+  {% include header.html %}
   <main class="container">
 
 <h2>&quot;The Elements for Electro Acoustics&quot;</h2>
@@ -42,6 +41,6 @@
 <p><a href="/works/">← back</a></p>
 
   </main>
-  <footer class="footer">© Myungseok Oh, 2025</footer>
+  {% include footer.html %}
 </body>
 </html>

--- a/works/to-my-mojave-2021/index.html
+++ b/works/to-my-mojave-2021/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -6,22 +8,19 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
+  <meta property="og:url" content="https://hearenzo.github.io/works/to-my-mojave-2021/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
-  <header class="container">
-    <h1><a href="/">Myungseok Oh</a></h1>
-    <nav>
-      <ul>
-        <li><a href="/">news</a></li>
-        <li><a href="/works/">works</a></li>
-        <li><a href="/recordings/">recordings</a></li>
-        <li><a href="/publications/">publications</a></li>
-        <li><a href="/biography/">biography</a></li>
-        <li><a href="/contact/">contact</a></li>
-      </ul>
-    </nav>
-    <hr />
-  </header>
+  {% include header.html %}
   <main class="container">
 
 <h2>&quot;To My Mojave&quot;</h2>
@@ -48,6 +47,6 @@
 <p><a href="/works/">← back</a></p>
 
   </main>
-  <footer class="footer">© Myungseok Oh, 2025</footer>
+  {% include footer.html %}
 </body>
 </html>

--- a/works/trans-2023/index.html
+++ b/works/trans-2023/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -6,22 +8,19 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
+  <meta property="og:url" content="https://hearenzo.github.io/works/trans-2023/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
-  <header class="container">
-    <h1><a href="/">Myungseok Oh</a></h1>
-    <nav>
-      <ul>
-        <li><a href="/">news</a></li>
-        <li><a href="/works/">works</a></li>
-        <li><a href="/recordings/">recordings</a></li>
-        <li><a href="/publications/">publications</a></li>
-        <li><a href="/biography/">biography</a></li>
-        <li><a href="/contact/">contact</a></li>
-      </ul>
-    </nav>
-    <hr />
-  </header>
+  {% include header.html %}
   <main class="container">
   
 <h2>&quot;TRANS&quot;</h2>
@@ -42,6 +41,6 @@
 <p><a href="/works/">← back</a></p>
 
   </main>
-  <footer class="footer">© Myungseok Oh, 2025</footer>
+  {% include footer.html %}
 </body>
 </html>

--- a/works/we-do-not-recall-2015/index.html
+++ b/works/we-do-not-recall-2015/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -6,22 +8,19 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
+  <meta property="og:url" content="https://hearenzo.github.io/works/we-do-not-recall-2015/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
-  <header class="container">
-    <h1><a href="/">Myungseok Oh</a></h1>
-    <nav>
-      <ul>
-        <li><a href="/">news</a></li>
-        <li><a href="/works/">works</a></li>
-        <li><a href="/recordings/">recordings</a></li>
-        <li><a href="/publications/">publications</a></li>
-        <li><a href="/biography/">biography</a></li>
-        <li><a href="/contact/">contact</a></li>
-      </ul>
-    </nav>
-    <hr />
-  </header>
+  {% include header.html %}
   <main class="container">
 
 <h2>&quot;WE DO NOT RECALL&quot;</h2>
@@ -40,6 +39,6 @@
 <p><a href="/works/">← back</a></p>
 
   </main>
-  <footer class="footer">© Myungseok Oh, 2025</footer>
+  {% include footer.html %}
 </body>
 </html>

--- a/works/zen-2019/index.html
+++ b/works/zen-2019/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -6,22 +8,19 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta property="og:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
+  <meta property="og:url" content="https://hearenzo.github.io/works/zen-2019/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
+  <meta name="twitter:image" content="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" />
 </head>
 <body>
-  <header class="container">
-    <h1><a href="/">Myungseok Oh</a></h1>
-    <nav>
-      <ul>
-        <li><a href="/">news</a></li>
-        <li><a href="/works/">works</a></li>
-        <li><a href="/recordings/">recordings</a></li>
-        <li><a href="/publications/">publications</a></li>
-        <li><a href="/biography/">biography</a></li>
-        <li><a href="/contact/">contact</a></li>
-      </ul>
-    </nav>
-    <hr />
-  </header>
+  {% include header.html %}
   <main class="container">
 
 <h2>&quot;Zen&quot;</h2>
@@ -37,6 +36,6 @@
 <p><a href="/works/">← back</a></p>
 
   </main>
-  <footer class="footer">© Myungseok Oh, 2025</footer>
+  {% include footer.html %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Extracted site-wide navigation and footer into reusable Jekyll includes
- Converted pages to use shared includes for consistency
- Added Open Graph and Twitter card meta tags for every work detail page

## Testing
- `gem install jekyll` *(fails: 403 "Forbidden")*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a471e41778832d81ff473546c8677f