### PR TITLE
feat: add lazy loading to embeds

### DIFF
--- a/recordings/index.html
+++ b/recordings/index.html
@@ -36,7 +36,7 @@
   <h2>recordings</h2>
 <ul class='list'>
   <li>
-    <iframe
+    <iframe loading="lazy"
       width="100%" height="166"
       scrolling="no" frameborder="no"
       allow="autoplay"
@@ -48,7 +48,7 @@
     </div>
   </li>
   <li>
-    <iframe
+    <iframe loading="lazy"
       width="100%" height="166"
       scrolling="no" frameborder="no"
       allow="autoplay"
@@ -60,7 +60,7 @@
     </div>
   </li>
   <li>
-    <iframe
+    <iframe loading="lazy"
       width="100%" height="166"
       scrolling="no" frameborder="no"
       allow="autoplay"
@@ -72,7 +72,7 @@
     </div>
   </li>
   <li>
-    <iframe
+    <iframe loading="lazy"
       width="100%" height="166"
       scrolling="no" frameborder="no"
       allow="autoplay"
@@ -84,7 +84,7 @@
     </div>
   </li>
   <li>
-    <iframe
+    <iframe loading="lazy"
       width="100%" height="166"
       scrolling="no" frameborder="no"
       allow="autoplay"

--- a/works/decodification-live-2022/index.html
+++ b/works/decodification-live-2022/index.html
@@ -27,7 +27,7 @@
 <h2>Decodification for Live Electronics</h2>
 <p class="meta">2022</p>
 <div class="video-container">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/-wbAdOSZ4Ac"
+  <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/-wbAdOSZ4Ac"
           title="Decodification for Live Electronics" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowfullscreen></iframe>

--- a/works/erasing-silence-2022/index.html
+++ b/works/erasing-silence-2022/index.html
@@ -27,7 +27,7 @@
 <h2>&quot;Erasing Silence&quot;</h2>
 <p class="meta">2022</p>
 <div class="video-container">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/IPGaetv-Cb0"
+  <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/IPGaetv-Cb0"
           title="&quot;Erasing Silence&quot;" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowfullscreen></iframe>

--- a/works/exploration-eight-sounds-2022/index.html
+++ b/works/exploration-eight-sounds-2022/index.html
@@ -27,7 +27,7 @@
 <h2>&quot;Exploration of Eight Sounds&quot; for Live Electronics</h2>
 <p class="meta">2022</p>
 <div class="video-container">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/9eyTuvCGrbU"
+  <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/9eyTuvCGrbU"
           title="&quot;Exploration of Eight Sounds&quot; for Live Electronics" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowfullscreen></iframe>

--- a/works/hotel-meta-2022/index.html
+++ b/works/hotel-meta-2022/index.html
@@ -27,7 +27,7 @@
 <h2>&quot;Hotel Meta&quot; — VR Exhibition</h2>
 <p class="meta">2022</p>
 <div class="video-container">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/_caYU4FkozM"
+  <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/_caYU4FkozM"
           title="&quot;Hotel Meta&quot; — VR Exhibition" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowfullscreen></iframe>

--- a/works/salvation-from-melancholy-2021/index.html
+++ b/works/salvation-from-melancholy-2021/index.html
@@ -27,7 +27,7 @@
 <h2>&quot;Salvation from Melancholy&quot;</h2>
 <p class="meta">2021</p>
 <div class="video-container">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/kACst7fiqN8"
+  <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/kACst7fiqN8"
           title="Salvation from Melancholy" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowfullscreen></iframe>

--- a/works/sensation-discovery-2022/index.html
+++ b/works/sensation-discovery-2022/index.html
@@ -27,7 +27,7 @@
 <h2>&quot;Sensation and Discovery&quot;: Playground of Eight Sounds</h2>
 <p class="meta">2022</p>
 <div class="video-container">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/HySczQ1A1xs"
+  <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/HySczQ1A1xs"
           title="&quot;Sensation and Discovery&quot;: Playground of Eight Sounds" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowfullscreen></iframe>

--- a/works/sonification-project-2019/index.html
+++ b/works/sonification-project-2019/index.html
@@ -27,7 +27,7 @@
 <h2>&quot;Sonification Project&quot;</h2>
 <p class="meta">2019</p>
 <div class="video-container">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/tQ-GNr6_M-A"
+  <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/tQ-GNr6_M-A"
           title="Sonification Project" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowfullscreen></iframe>

--- a/works/the-elements-for-electro-acoustics-2021/index.html
+++ b/works/the-elements-for-electro-acoustics-2021/index.html
@@ -27,7 +27,7 @@
 <h2>&quot;The Elements for Electro Acoustics&quot;</h2>
 <p class="meta">2021</p>
 <div class="video-container">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/PC7w2k8bUfg"
+  <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/PC7w2k8bUfg"
           title="The Elements for Electro Acoustics" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowfullscreen></iframe>

--- a/works/to-my-mojave-2021/index.html
+++ b/works/to-my-mojave-2021/index.html
@@ -27,7 +27,7 @@
 <h2>&quot;To My Mojave&quot;</h2>
 <p class="meta">2021</p>
 <div class="video-container">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/hyJRPSuJHto"
+  <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/hyJRPSuJHto"
           title="&quot;To My Mojave&quot;" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowfullscreen></iframe>

--- a/works/trans-2023/index.html
+++ b/works/trans-2023/index.html
@@ -27,7 +27,7 @@
 <h2>&quot;TRANS&quot;</h2>
 <p class="meta">2023</p>
 <div class="video-container">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/Ew7WXLwUQYY"
+  <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/Ew7WXLwUQYY"
           title="&quot;TRANS&quot;" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowfullscreen></iframe>

--- a/works/we-do-not-recall-2015/index.html
+++ b/works/we-do-not-recall-2015/index.html
@@ -27,7 +27,7 @@
 <h2>&quot;WE DO NOT RECALL&quot;</h2>
 <p class="meta">2015</p>
 <div class="video-container">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/5eo1pxXyBXQ"
+  <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/5eo1pxXyBXQ"
           title="&quot;WE DO NOT RECALL&quot;" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowfullscreen></iframe>

--- a/works/zen-2019/index.html
+++ b/works/zen-2019/index.html
@@ -27,7 +27,7 @@
 <h2>&quot;Zen&quot;</h2>
 <p class="meta">2019</p>
 <div class="video-container">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/SVTKuBh3r9k"
+  <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/SVTKuBh3r9k"
           title="&quot;ZEN&quot;" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowfullscreen></iframe>


### PR DESCRIPTION
## Summary
- add `loading="lazy"` to all iframe embeds in recordings and works pages

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -I https://www.youtube.com/embed/-wbAdOSZ4Ac | head -n 5` *(403 Forbidden)*
- `curl -I "https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/hearenzo/fractal-resonance&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true" | head -n 5` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a471eae4c0832d82645b7b767eaf01