### PR TITLE
Add robots.txt and sitemap for search visibility

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://hearenzo.github.io/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://hearenzo.github.io/</loc></url>
+  <url><loc>https://hearenzo.github.io/biography/</loc></url>
+  <url><loc>https://hearenzo.github.io/contact/</loc></url>
+  <url><loc>https://hearenzo.github.io/publications/</loc></url>
+  <url><loc>https://hearenzo.github.io/recordings/</loc></url>
+  <url><loc>https://hearenzo.github.io/works/</loc></url>
+  <url><loc>https://hearenzo.github.io/works/decodification-live-2022/</loc></url>
+  <url><loc>https://hearenzo.github.io/works/erasing-silence-2022/</loc></url>
+  <url><loc>https://hearenzo.github.io/works/exploration-eight-sounds-2022/</loc></url>
+  <url><loc>https://hearenzo.github.io/works/hotel-meta-2022/</loc></url>
+  <url><loc>https://hearenzo.github.io/works/salvation-from-melancholy-2021/</loc></url>
+  <url><loc>https://hearenzo.github.io/works/sensation-discovery-2022/</loc></url>
+  <url><loc>https://hearenzo.github.io/works/sonification-project-2019/</loc></url>
+  <url><loc>https://hearenzo.github.io/works/the-elements-for-electro-acoustics-2021/</loc></url>
+  <url><loc>https://hearenzo.github.io/works/to-my-mojave-2021/</loc></url>
+  <url><loc>https://hearenzo.github.io/works/trans-2023/</loc></url>
+  <url><loc>https://hearenzo.github.io/works/we-do-not-recall-2015/</loc></url>
+  <url><loc>https://hearenzo.github.io/works/zen-2019/</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- Add `robots.txt` that allows all crawlers and references the sitemap
- Generate `sitemap.xml` listing all site pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a471ec7444832da7d02c77c13b7f19