### PR TITLE
Add Strudel demo recording

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -130,3 +130,11 @@ h3 {
   width: 100%;
   aspect-ratio: 16 / 9;
 }
+
+/* Strudel iframe */
+.strudel-container {
+  width: 100%;
+  height: 240px;
+  border: 0;
+  margin: 4px 0;
+}

--- a/recordings/index.html
+++ b/recordings/index.html
@@ -25,6 +25,9 @@
   <h2>recordings</h2>
 <ul class='list'>
   <li>
+    <iframe class="strudel-container" src="strudel.html" loading="lazy"></iframe>
+  </li>
+  <li>
     <iframe loading="lazy"
       width="100%" height="166"
       scrolling="no" frameborder="no"

--- a/recordings/strudel.html
+++ b/recordings/strudel.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Strudel Demo</title>
+  <script type="module">
+    import { startAudio, run } from "https://cdn.jsdelivr.net/npm/@strudel/web@latest/dist/web.mjs";
+    startAudio();
+    run("bd sn [bd sn]*2");
+  </script>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone Strudel demo page that plays a simple pattern
- embed the demo in recordings index via iframe
- style Strudel iframes with new CSS class

## Testing
- `npm test`
- `npm run build`
- `curl -s http://localhost:8000/strudel.html | head`


------
https://chatgpt.com/codex/tasks/task_b_68a47552efd8832dbbae4d61c50648b5