### PR TITLE
fix: load Strudel embed script as module

### DIFF
--- a/recordings/strudel.html
+++ b/recordings/strudel.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>Strudel Embed</title>
   <meta name="Bit Sync" content="width=device-width, initial-scale=1" />
-  <script src="https://unpkg.com/@strudel/embed@latest"></script>
+  <script type="module" src="https://unpkg.com/@strudel/embed@latest"></script>
   <style>
     html,body{margin:0;height:100%}
     .wrap{min-height:100%;display:flex}


### PR DESCRIPTION
## Summary
- load Strudel embed script as ES module so browser uses module loader

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a485ad550c832d8877d698cc7159d3