### PR TITLE
Increase Strudel container height

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -134,7 +134,8 @@ h3 {
 /* Strudel iframe */
 .strudel-container {
   width: 100%;
-  height: 240px;
+  height: auto;
+  min-height: 420px;
   border: 0;
   margin: 4px 0;
 }


### PR DESCRIPTION
## Summary
- ensure `.strudel-container` iframe has a minimum height of 420px for better embed rendering

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a485b2f97c832daeabf64d624a331f