### PR TITLE
Embed Strudel code directly

### DIFF
--- a/recordings/strudel.html
+++ b/recordings/strudel.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>Strudel Embed</title>
   <meta name="Bit Sync" content="width=device-width, initial-scale=1" />
-  <script src="https://unpkg.com/@strudel/embed@latest"></script>
+  <script type="module" src="https://unpkg.com/@strudel/embed@latest"></script>
   <style>
     html,body{margin:0;height:100%}
     .wrap{min-height:100%;display:flex}
@@ -13,10 +13,8 @@
 </head>
 <body>
   <div class="wrap">
-    <strudel-repl></strudel-repl>
-  </div>
-  <!--
-// Made by enzo 
+    <strudel-repl>
+// Made by enzo
 
 // 1. 메인 pulse: 초고음 sine, 밀고 당기는 엇박/syncopation
 $: note("[a4 a7 ~ a8 ~ a7 a8 ~]/8")
@@ -41,7 +39,7 @@ $: note("[a4 a4 ~ a6 ~ a7 a8 ~]/9")
   .slow(1.25)
 .spectrum()
 
-// 2. white noise layer 
+// 2. white noise layer
 $: n("[a4 a7 ~ a8 ~ a7 a8 ~]/9")
   .sound("white")
   .gain("[.19 .16 .14 .21 .18 .15 .22 .17]/8")
@@ -53,7 +51,7 @@ $: n("[a4 a7 ~ a8 ~ a7 a8 ~]/9")
   //.slow(1.08)
 .spectrum()
 
-// 3. triangle pulse 
+// 3. triangle pulse
 $: note("[a1 ~ a0 a1 ~ a1 ~ a0]/8")
   .sound("triangle")
   .gain("[.42 0 .28 .23 0 .25 .22 .33]/8")
@@ -76,7 +74,7 @@ $: note("[a1 ~ a4 a1 ~ a1 ~ a0]/8")
   //.slow(1.16)
 .spectrum()
 
-// 5. triangle minimal space pulse 
+// 5. triangle minimal space pulse
 $: note("<a0 a1 a8>/2")
   .sound("triangle")
   .gain("[.01 .07 .2]/6")
@@ -92,8 +90,9 @@ $: note("c1*8").s("wt_dbass").n(run(8))
   .lpf(perlin.range(100,1000).slow(8))
   .lpenv(-3).lpa(.1).room(.5).fast(2)
   .mask("<1 0 1 1 0 1 1 0>/5")
-  
+
 .spectrum()
-  -->
+    </strudel-repl>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Embed Strudel sequence directly inside `<strudel-repl>` in `recordings/strudel.html`
- Remove HTML comment wrapper so Strudel code runs in the REPL
- Load Strudel embed script as module to render the REPL correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a485b2a5f4832db17267020554556b