### PR TITLE
Move artistic statement to works page and update bio

### DIFF
--- a/biography/index.html
+++ b/biography/index.html
@@ -25,42 +25,11 @@
   <main class="container">
     <h2>biography</h2>
 
-    <h3>artistic statement</h3>
-    <p>
-Creating art using sound is a process that is not entirely within my control. It is the
-result of both my experiences and choices. The completed work is the result of
-my decisions, which are made under circumstances that I cannot always predict
-or control. This is similar to the path that life takes us on, where we cannot go
-back to the crossroads that we have already passed. The creative process is like
-a prism that refracts light, and it represents my approach to life and my work.
-</p>
-<p>
-The human eye perceives light as a single color, but most people understand that
-there are multiple colors within a single beam of light. This is because of the
-prism, which can disperse light and reveal its various hues. The prism allows us to
-explore the essence of things, rather than accepting the information presented to
-us at face value. This is the effect that I hope my work will have on its audience. I
-aspire to create art that delves deeper into the essence of things, that doesn't just
-accept information at face value, and that goes beyond virtual or replicated
-reality.
-</p>
-<p>
-Imagine making plans to meet someone. Instead of moving physically, we use our
-smartphones to calculate the fastest route to the meeting place. If public
-transportation is delayed, we blame the physical world rather than the virtual one.
-This is a paradoxical attitude, as we live our lives according to the virtual
-information that we receive but are unhappy when it doesn't align with the
-physical reality. Through my art, I hope to function as a prism, revealing a deeper,
-truer essence of reality.
-</p>
-<p>
-Therefore, my exhibited works are natural elements that are intertwined with our
-daily lives. I deconstruct familiar objects and elements to create my works. The
-scent of my perfume, the withered trees of autumn, the concrete used in seawalls
-on the opposite side of the globe, and the space in which I live are all elements
-that I use. The resulting work is not just an end product but a reflection of my
-experiences, choices, and the essence of the natural elements that inspired it.
-</p>
+    <p>Oh, Myungseok (b.1995, Seoul, Korea) is a sound artist and artistic researcher whose work explores how sound can function as a prism—fracturing and refracting our perception of time, space, and reality. His practice examines the paradox between virtual systems and physical experience, seeking to reveal deeper essences beyond what is immediately perceptible.</p>
+    <p>He holds a Master of Arts and Science in Art &amp; Technology from Sogang University, where his thesis focused on deep learning and vocalization evaluation, and a BFA in Media Arts from the Seoul Institute of the Arts. His career spans artistic research, sound design, and AI, bridging experimental performance with cutting-edge technology.</p>
+    <p>Oh’s work has been presented internationally and supported by organizations such as the Arts Council Korea (ARKO), Seoul Foundation for Arts and Culture (SFAC), and KOCCA. He has participated in residencies at the Stochastic Labs of the Minerva Foundation in Berkeley (2023), La MaMa Umbria at the 61st Spoleto Festival in Italy (2018), and Experimental Film Virginia in the U.S. (2015).</p>
+    <p>His projects have been recognized with awards including the KEA Award for Excellence in Research (2022), the ARKO Artist-Producer-Engineer Camp Winner (2022), and a Special Mention at the European Young Theatre for Controller and Driver (2018).</p>
+    <p>Currently, Oh is a resident at Stochastic Labs in Berkeley, researching the future of music and sound, while also working as an AI Product Manager at Krafton, where he integrates artistic experimentation with technological innovation.</p>
 
     <h3>education</h3>
     <ul class="list">

--- a/works/index.html
+++ b/works/index.html
@@ -23,6 +23,42 @@
   {% include header.html %}
   <main class="container">
   <h2>works</h2>
+  <h3>artistic statement</h3>
+  <p>
+Creating art using sound is a process that is not entirely within my control. It is the
+result of both my experiences and choices. The completed work is the result of
+my decisions, which are made under circumstances that I cannot always predict
+or control. This is similar to the path that life takes us on, where we cannot go
+back to the crossroads that we have already passed. The creative process is like
+a prism that refracts light, and it represents my approach to life and my work.
+  </p>
+  <p>
+The human eye perceives light as a single color, but most people understand that
+there are multiple colors within a single beam of light. This is because of the
+prism, which can disperse light and reveal its various hues. The prism allows us to
+explore the essence of things, rather than accepting the information presented to
+us at face value. This is the effect that I hope my work will have on its audience. I
+aspire to create art that delves deeper into the essence of things, that doesn't just
+accept information at face value, and that goes beyond virtual or replicated
+reality.
+  </p>
+  <p>
+Imagine making plans to meet someone. Instead of moving physically, we use our
+smartphones to calculate the fastest route to the meeting place. If public
+transportation is delayed, we blame the physical world rather than the virtual one.
+This is a paradoxical attitude, as we live our lives according to the virtual
+information that we receive but are unhappy when it doesn't align with the
+physical reality. Through my art, I hope to function as a prism, revealing a deeper,
+truer essence of reality.
+  </p>
+  <p>
+Therefore, my exhibited works are natural elements that are intertwined with our
+daily lives. I deconstruct familiar objects and elements to create my works. The
+scent of my perfume, the withered trees of autumn, the concrete used in seawalls
+on the opposite side of the globe, and the space in which I live are all elements
+that I use. The resulting work is not just an end product but a reflection of my
+experiences, choices, and the essence of the natural elements that inspired it.
+  </p>
 <ul class='list'>
 <li><a href="/works/trans-2023/">&quot;TRANS&quot; - Dance</a> <span class="meta">2023</span></li>
 <li><a href="/works/hotel-meta-2022/">&quot;Hotel Meta&quot; - VR Exhibition</a> <span class="meta">2022</span></li>


### PR DESCRIPTION
## Summary
- Move the artistic statement from the biography page to the works page so it appears above the list of projects.
- Replace the biography's artistic statement with an updated artist bio.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a4954adc08832d91813c5c9c1f32e0