### PR TITLE
Update favicon and metadata image

### DIFF
--- a/assets/img/favicon.svg
+++ b/assets/img/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <rect width="1024" height="1024" fill="#ffffff"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Noto Sans KR',Arial,sans-serif" font-size="512" fill="#000000">h</text>
+</svg>

--- a/biography/index.html
+++ b/biography/index.html
@@ -8,7 +8,7 @@
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <link rel="stylesheet" href="/assets/css/styles.min.css" />
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:image" content="https://hearenzo.github.io/assets/img/og.svg" />

--- a/contact/index.html
+++ b/contact/index.html
@@ -8,7 +8,7 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.min.css" />
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:image" content="https://hearenzo.github.io/assets/img/og.svg" />

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.min.css" />
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:image" content="https://hearenzo.github.io/assets/img/og.svg" />

--- a/publications/index.html
+++ b/publications/index.html
@@ -8,7 +8,7 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.min.css" />
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:image" content="https://hearenzo.github.io/assets/img/og.svg" />

--- a/recordings/index.html
+++ b/recordings/index.html
@@ -8,7 +8,7 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.min.css" />
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:image" content="https://hearenzo.github.io/assets/img/og.svg" />

--- a/works/decodification-live-2022/index.html
+++ b/works/decodification-live-2022/index.html
@@ -8,7 +8,7 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.min.css" />
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:image" content="https://hearenzo.github.io/assets/img/og.svg" />

--- a/works/erasing-silence-2022/index.html
+++ b/works/erasing-silence-2022/index.html
@@ -8,7 +8,7 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.min.css" />
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:image" content="https://hearenzo.github.io/assets/img/og.svg" />

--- a/works/exploration-eight-sounds-2022/index.html
+++ b/works/exploration-eight-sounds-2022/index.html
@@ -8,7 +8,7 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.min.css" />
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:image" content="https://hearenzo.github.io/assets/img/og.svg" />

--- a/works/hotel-meta-2022/index.html
+++ b/works/hotel-meta-2022/index.html
@@ -8,7 +8,7 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.min.css" />
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:image" content="https://hearenzo.github.io/assets/img/og.svg" />

--- a/works/index.html
+++ b/works/index.html
@@ -8,7 +8,7 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.min.css" />
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:image" content="https://hearenzo.github.io/assets/img/og.svg" />

--- a/works/salvation-from-melancholy-2021/index.html
+++ b/works/salvation-from-melancholy-2021/index.html
@@ -8,7 +8,7 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.min.css" />
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:image" content="https://hearenzo.github.io/assets/img/og.svg" />

--- a/works/sensation-discovery-2022/index.html
+++ b/works/sensation-discovery-2022/index.html
@@ -8,7 +8,7 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.min.css" />
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:image" content="https://hearenzo.github.io/assets/img/og.svg" />

--- a/works/sonification-project-2019/index.html
+++ b/works/sonification-project-2019/index.html
@@ -8,7 +8,7 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.min.css" />
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:image" content="https://hearenzo.github.io/assets/img/og.svg" />

--- a/works/the-elements-for-electro-acoustics-2021/index.html
+++ b/works/the-elements-for-electro-acoustics-2021/index.html
@@ -8,7 +8,7 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.min.css" />
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:image" content="https://hearenzo.github.io/assets/img/og.svg" />

--- a/works/to-my-mojave-2021/index.html
+++ b/works/to-my-mojave-2021/index.html
@@ -8,7 +8,7 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.min.css" />
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:image" content="https://hearenzo.github.io/assets/img/og.svg" />

--- a/works/trans-2023/index.html
+++ b/works/trans-2023/index.html
@@ -8,7 +8,7 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.min.css" />
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:image" content="https://hearenzo.github.io/assets/img/og.svg" />

--- a/works/we-do-not-recall-2015/index.html
+++ b/works/we-do-not-recall-2015/index.html
@@ -8,7 +8,7 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.min.css" />
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:image" content="https://hearenzo.github.io/assets/img/og.svg" />

--- a/works/zen-2019/index.html
+++ b/works/zen-2019/index.html
@@ -8,7 +8,7 @@
   <title>Myungseok Oh | Researcher, Sound Artist, Based in Seoul</title>
   <meta name="description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <link rel="stylesheet" href="/assets/css/styles.min.css" />
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAwUBAO2A9gAAAABJRU5ErkJggg==" type="image/png" />
+  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:description" content="Myungseok Oh | Researcher, Sound Artist, Based in Seoul" />
   <meta property="og:image" content="https://hearenzo.github.io/assets/img/og.svg" />


### PR DESCRIPTION
## Summary
- replace bitmap icons with SVG alternatives
- point favicon, Open Graph, and Twitter metadata to SVG artwork

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a9714e8efc832dbffe3d9af048cfbd