### PR TITLE
Add hero section with background media and audio toggle

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -150,3 +150,29 @@ h3 {
   color: var(--muted);
   text-decoration: none;
 }
+
+/* Hero section */
+.hero {
+  position: relative;
+  height: 100vh;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.hero video,
+.hero img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.hero button {
+  position: relative;
+  z-index: 1;
+}

--- a/index.html
+++ b/index.html
@@ -21,11 +21,33 @@
 </head>
 <body>
   {% include header.html %}
-  <main class="container">
-  <h2>news</h2>
-<ul class='list'>
-  <li>10.11 | "TRANS III After Talk &amp; Screening" | <a href="https://www.instagram.com/studio__offbeat" target="_blank" rel="noopener noreferrer">Studio Offbeat</a> <span class="meta">A conversation and screening reflecting on the project.</span></li>
-</ul>
+  <main>
+    <section class="hero">
+      <video class="hero-media" autoplay loop muted playsinline>
+        <source src="https://www.w3schools.com/html/mov_bbb.mp4" type="video/mp4" />
+      </video>
+      <audio id="hero-audio" src="https://www.w3schools.com/html/horse.mp3" loop></audio>
+      <button id="sound-toggle">Sound on</button>
+    </section>
+    <div class="container">
+      <h2>news</h2>
+      <ul class='list'>
+        <li>10.11 | "TRANS III After Talk &amp; Screening" | <a href="https://www.instagram.com/studio__offbeat" target="_blank" rel="noopener noreferrer">Studio Offbeat</a> <span class="meta">A conversation and screening reflecting on the project.</span></li>
+      </ul>
+    </div>
+    <script>
+      const audio = document.getElementById('hero-audio');
+      const btn = document.getElementById('sound-toggle');
+      btn.addEventListener('click', () => {
+        if (audio.paused) {
+          audio.play();
+          btn.textContent = 'Sound off';
+        } else {
+          audio.pause();
+          btn.textContent = 'Sound on';
+        }
+      });
+    </script>
   </main>
   {% include footer.html %}
 </body>


### PR DESCRIPTION
## Summary
- Add hero section with background video and optional audio in the homepage
- Include script to toggle audio playback for visitors
- Style hero for full-viewport layout and cover background media

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a97f2e42e4832d828daa30a6f650d7