### PR TITLE
Use Jekyll relative_url for Strudel demo

### DIFF
--- a/recordings/index.html
+++ b/recordings/index.html
@@ -6,9 +6,9 @@ description: "Myungseok Oh | Researcher, Sound Artist, Based in Seoul"
   <h2>recordings</h2>
 <ul class='list'>
   <li>
-    <iframe class="strudel-container" src="strudel.html" loading="lazy" title="Strudel demo"></iframe>
+    <iframe class="strudel-container" src="{{ '/recordings/strudel.html' | relative_url }}" loading="lazy" title="Strudel demo"></iframe>
     <div class="sc-credits">
-      <a href="strudel.html" target="_blank" rel="noopener noreferrer">Interactive Strudel demo</a>
+      <a href="{{ '/recordings/strudel.html' | relative_url }}" target="_blank" rel="noopener noreferrer">Interactive Strudel demo</a>
     </div>
   </li>
   <li>


### PR DESCRIPTION
## Summary
- use `relative_url` filter for Strudel demo iframe and link to ensure proper path resolution

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b30f0f1044832da39c1602fd1d889a