### PR TITLE
fix: remove duplicate footer on biography page

### DIFF
--- a/biography/index.html
+++ b/biography/index.html
@@ -79,10 +79,8 @@ description: "Myungseok Oh | Researcher, Sound Artist, Based in Seoul"
     <ul class="list">
       <li>ARKO Artist, Producer, Engineer Camp Winner (2022)</li>
       <li>KEA Award for Excellence in Research (2022)</li>
-      <li>European Young Theatre Special Mention — “Controller and Driver” (2018) —
-        <a href="https://www.hankookilbo.com/News/Read/201807181662031986" target="_blank" rel="noopener noreferrer">press</a>
-      </li>
-    </ul>
-  {% include footer.html %}
-</body>
-</html>
+    <li>European Young Theatre Special Mention — “Controller and Driver” (2018) —
+      <a href="https://www.hankookilbo.com/News/Read/201807181662031986" target="_blank" rel="noopener noreferrer">press</a>
+    </li>
+  </ul>
+


### PR DESCRIPTION
## Summary
- stop biography page from including its own footer and closing tags

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b30fbdff4c832d800515fe56c40821