### PR TITLE
chore: pin strudel embed version

### DIFF
--- a/recordings/strudel.html
+++ b/recordings/strudel.html
@@ -5,7 +5,7 @@
   <title>Strudel Embed</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Interactive Strudel code example" />
-  <script defer src="https://unpkg.com/@strudel/embed@latest"></script>
+  <script defer src="https://unpkg.com/@strudel/embed@0.27.0" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous"></script>
   <style>
     html,body{margin:0;height:100%}
     .wrap{min-height:100%;display:flex}


### PR DESCRIPTION
## Summary
- pin Strudel embed script to explicit version 0.27.0
- add SRI and crossorigin attributes for reliable loading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b3e0f4e178832dac4db7c79c70a0b5